### PR TITLE
Add support for Nextar tracking commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Added:
+
+ - Support for Nexstar tracking commands: t and T
+
 ## v0.0.5 - 2021-01-17
 
 Changed:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
 
-PROJECT_VERSION           := 0.0.5
+PROJECT_VERSION           := 0.0.6
 DOCKER_REPO               := synfinatic
 PROJECT_NAME              := alpacascope
 PROJECT_TAG               := $(shell git describe --tags 2>/dev/null $(git rev-list --tags --max-count=1))

--- a/README.md
+++ b/README.md
@@ -159,3 +159,15 @@ If you wish to build your own binary on Windows, you'll need to do:
  1. Run `make help` to get a list of other OS targets you can build.  Note that 
     GoLang makes cross-compiling easy so no problems building a Windows binary
     on Linux or MacOS binary on a RaspberryPi. :)
+
+#### What is the purpose of the --mount-type flag?
+
+The Celestron Nexstar protocol supports the concept of different tracking modes:
+AltAz, EQ North, EQ South and Off.  Typically this would be used with a AltAz 
+fork mount which can optionally have a wedge.  The result is the mount must be 
+told to change it's tracking mode.
+
+However, Alpaca/ASCOM does not support this- it only allows you to turn on & 
+off tracking.  Hence, AlpacaScope allows you to specify the mount type at startup,
+and then when SkySafari/etc queries the current tracking mode it will get the
+correct answer.

--- a/cmd/nexstar.go
+++ b/cmd/nexstar.go
@@ -99,8 +99,24 @@ func nexstar_command(t *alpaca.Telescope, len int, buf []byte) []byte {
 		alt_int := uint32(alt / 360.0 * 4294967296.0)
 		ret = fmt.Sprintf("%08X,%08X#", azm_int, alt_int)
 
-	case 't', 'T':
-		log.Errorf("Tracking commands (%c) are not supported by ASCOM", buf[0])
+	case 't':
+		// get tracking mode
+		mode, err := t.GetTracking()
+		if err != nil {
+			log.Errorf("Unable to get tracking mode: %s", err.Error())
+			break
+		}
+		ret = fmt.Sprintf("%d#", mode)
+
+	case 'T':
+		// set tracking mode
+		var tracking_mode alpaca.TrackingMode
+		fmt.Sscanf(string(buf[1]), "%d", &tracking_mode)
+		err := t.PutTracking(tracking_mode)
+		if err != nil {
+			log.Errorf("Unable to set tracking mode: %s", err.Error())
+			break
+		}
 		ret = "#"
 
 	case 'V':


### PR DESCRIPTION
You can now specify the mount type so that we can
switch between tracking on and off.  Note that the
mount type and tracking mode can not be changed other than via the CLI.

Meaning, you can't switch between AltAz and EQ-North, but you can turn
on and off tracking.  This is because ASCOM/Alpaca does not support the
concept of tracking modes which AFAIK only really exists with AltAz
mounts that optionally support a wedge... just tracking.

Fixes: #15