### PR TITLE
Add support for auto-tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+Added:
+
+ - SkySafari's "Stop" action will disable tracking which for some mounts
+    will prevent future goto's until tracking is re-enabled.  AlpacaScope 
+    will now optionally check for this situation and re-enable tracking 
+    for goto's to be successful.
+
+## v2.1.0 - 2021-07-31
+
+Added:
+
+ - Ability to save/read configuration settings across executions.
+
 Changed:
 
  - Selecting mount type is only supported with NexStar protocol 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
 
-PROJECT_VERSION           := 2.1.0
+PROJECT_VERSION           := 2.2.0
 BUILD_ID                  := 1
 DOCKER_REPO               := synfinatic
 PROJECT_NAME              := alpacascope

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,7 @@ func main() {
 	var shost string    // Alpaca server IP
 	var version bool    //  Version info
 	var _mode string    // Comms mode
+	var noAutoTrack bool
 	var mode TeleComms
 	var telescopeId uint32 // Alpaca telescope id.  Usually 0-10
 	var _mount_type string // mount type
@@ -71,6 +72,7 @@ func main() {
 	flag.StringVar(&_mode, "mode", "nexstar", "Comms mode: [nexstar|lx200]")
 	flag.Uint32Var(&telescopeId, "telescope-id", 0, "Alpaca Telescope ID")
 	flag.StringVar(&_mount_type, "mount-type", "altaz", "Mount type: [altaz|eqn|eqs]")
+	flag.BoolVar(&noAutoTrack, "no-auto-track", false, "Do not enable auto-track")
 
 	flag.Parse()
 
@@ -175,9 +177,9 @@ func main() {
 		if err != nil {
 			log.Errorf("Unable to query axis rates: %s", err.Error())
 		}
-		tscope = telescope.NewLX200(true, true, minmax, 100000)
+		tscope = telescope.NewLX200(!noAutoTrack, true, true, minmax, 100000)
 	case NexStar:
-		tscope = telescope.NewNexStar()
+		tscope = telescope.NewNexStar(!noAutoTrack)
 	default:
 		log.Fatalf("Unsupported mode value: %d", mode)
 	}

--- a/gui/config.go
+++ b/gui/config.go
@@ -29,6 +29,7 @@ import (
 type AlpacaScopeConfig struct {
 	TelescopeProtocol string `json:"TelescopeProtocol"`
 	TelescopeMount    string `json:"TelescopeMount"`
+	AutoTracking      bool   `json:"AutoTracking"`
 	ListenIp          string `json:"ListenIp"`
 	ListenPort        string `json:"ListenPort"`
 	AscomAuto         bool   `json:"AscomAuto"`
@@ -48,6 +49,7 @@ func NewAlpacaScopeConfig() (*AlpacaScopeConfig, error) {
 	config := &AlpacaScopeConfig{
 		TelescopeProtocol: "NexStar",
 		TelescopeMount:    "Alt-Az",
+		AutoTracking:      true,
 		AscomAuto:         true,
 		ListenIp:          "All-Interfaces/0.0.0.0",
 		ListenPort:        "4030",

--- a/gui/main.go
+++ b/gui/main.go
@@ -47,6 +47,7 @@ var sbox *StatusBox
 type Widgets struct {
 	TelescopeProtocol *widget.Select
 	TelescopeMount    *widget.Select
+	AutoTracking      *widget.Check
 	ListenIp          *widget.Select
 	ListenPort        *widget.Entry
 	AscomAuto         *widget.Check
@@ -77,6 +78,7 @@ func main() {
 	top := widget.NewForm(
 		widget.NewFormItem("Telescope Protocol", ourWidgets.TelescopeProtocol),
 		widget.NewFormItem("Mount Type", ourWidgets.TelescopeMount),
+		widget.NewFormItem("Auto Tracking", ourWidgets.AutoTracking),
 		widget.NewFormItem("Listen IP", ourWidgets.ListenIp),
 		widget.NewFormItem("Listen Port", ourWidgets.ListenPort),
 		widget.NewFormItem("Auto Discover ASCOM Remote", ourWidgets.AscomAuto),
@@ -249,10 +251,10 @@ func (c *AlpacaScopeConfig) Run() {
 		if err != nil {
 			sbox.AddLine(fmt.Sprintf("Unable to query axis rates: %s", err.Error()))
 		}
-		tscope = telescope.NewLX200(true, true, minmax, 100000)
+		tscope = telescope.NewLX200(c.AutoTracking, true, true, minmax, 100000)
 
 	case "NexStar":
-		tscope = telescope.NewNexStar()
+		tscope = telescope.NewNexStar(c.AutoTracking)
 	}
 
 	// Act like SkyFi
@@ -396,6 +398,18 @@ func NewWidgets(config *AlpacaScopeConfig) *Widgets {
 	if config.TelescopeProtocol == "LX200" {
 		w.TelescopeMount.Disable()
 	}
+
+	// AutoTracking
+	w.AutoTracking = widget.NewCheck("", func(enabled bool) {
+		switch enabled {
+		case true:
+			config.AutoTracking = true
+		case false:
+			config.AutoTracking = false
+		}
+
+	})
+	w.AutoTracking.Checked = config.AutoTracking
 
 	// ListenIp
 	ips, err := utils.GetLocalIPs()


### PR DESCRIPTION
When SkySafari does a "stop" the mount will stop tracking and no longer
accept further go-to commands.

Fixes: #39