### PR TITLE
disable high precision LX200 by default and add option

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Install X11
-      run: sudo apt-get install -y xorg-dev
+    - name: Install X11/OpenGL
+      run: sudo apt-get update && sudo apt-get install -y xorg-dev
 
     - name: Set up Go 1.15
       uses: actions/setup-go@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,21 @@
 # AlpacaScope Changelog
 
-## v2.2.3 - 2021-12-05
+## v2.2.3 - 2021-12-06
+
+Fixed:
+
+ - LX200 mode now defaults to disabling "high precision" mode #51
+ - GUI now consistently (un)shades text labels associated with disabled widgets
 
 Changed:
 
- - LX200 mode now defaults to disabling "high precision" mode #51
- - Both GUI and CLI now support toggling high precision mode to be on or 
-    off by default on startup so that you can enable high precision 
+ - Both GUI and CLI now support toggling high precision mode to be on or
+    off by default on startup so that you can enable high precision
     by default to replicate the old behavior.
+ - Clients providing goto coordinates in LX200 mode can now specify
+    high or low precision values and we will parse it appropriately
+    regardless of the specified mode.
+
 
 ## v2.2.2 - 2021-11-11
 
@@ -31,8 +39,8 @@ Changed:
 Added:
 
  - SkySafari's "Stop" action will disable tracking which for some mounts
-    will prevent future goto's until tracking is re-enabled.  AlpacaScope 
-    will now optionally check for this situation and re-enable tracking 
+    will prevent future goto's until tracking is re-enabled.  AlpacaScope
+    will now optionally check for this situation and re-enable tracking
     for goto's to be successful. #41
 
 Changed:
@@ -52,7 +60,7 @@ Added:
 
 Changed:
 
- - Selecting mount type is only supported with NexStar protocol 
+ - Selecting mount type is only supported with NexStar protocol
  - Updated makefile targets
  - Updated readme
  - Add improved docs for configuration
@@ -107,7 +115,7 @@ Fixed:
 
 Added:
 
- - Info about viruses and how to build on Windows 
+ - Info about viruses and how to build on Windows
  - Git workflow for building & testing
  - Add Linux-ARM binary for RasPi
  - Add support for Alpaca discovery via: --alpaca-host auto
@@ -138,7 +146,7 @@ Fixed:
 
 ## v0.0.2 - 2020-12-23
 
-Fixed: 
+Fixed:
 
  - Properly close Nexstar client TCP sockets that are no longer in use.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # AlpacaScope Changelog
 
+## v2.2.3 - 2021-12-05
+
+Changed:
+
+ - LX200 mode now defaults to disabling "high precision" mode #51
+ - Both GUI and CLI now support toggling high precision mode to be on or 
+    off by default on startup so that you can enable high precision 
+    by default to replicate the old behavior.
+
 ## v2.2.2 - 2021-11-11
 
 Added:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
 
-PROJECT_VERSION           := 2.2.2
+PROJECT_VERSION           := 2.2.3
 BUILD_ID                  := 1
 DOCKER_REPO               := synfinatic
 PROJECT_NAME              := alpacascope

--- a/README.md
+++ b/README.md
@@ -112,9 +112,31 @@ Alpaca standards.
 
 No!  AlpacaScope works with any telescope / mount supported by Alpaca or
 ASCOM.  The LX200 and NexStar protocols are only for communicating with software
-like SkySafari.  You can even use the LX200 protocol with your Celestron scope
-if you want because AlpacaScope does all the translating between the different
-protocols.
+like SkySafari or StarryNight.  You can even use the LX200 protocol with your 
+Celestron scope if you want because AlpacaScope does all the translating between
+the different protocols.
+
+#### Should I use NexStar or LX200 protocol?
+
+Short version: 
+
+No matter what kind of telescope you have, you probably want 
+to pick `NexStar` in AlpacaScope.  In SkySafari and StarryNight, you should choose 
+`Celestron NexStar/Advanced GT`.
+
+Longer story:
+
+The protocol spec for Celestron NexStar is more consistently implimented
+in my experience and users report a lot more issues with LX200.  So I would
+definitely recommend people try `NexStar` before `LX200`.  Yes, this even
+means people with a Meade LX200 series telescope should probably choose 
+`NexStar`!  Yes, that is _very confusing_ but trust me. :)
+
+That said, I understand there are cases where you might need to use LX200
+and I do my very best to support it.  If you experience any compatibility
+issues, please let me know so I can try to either fix the bug in my code
+or develop a work-around for poorly behaved clients.
+
 
 #### What do I need at minimum?
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,14 +49,15 @@ const (
 )
 
 func main() {
-	var lport int32     // listen port
-	var lip string      // listen IP
-	var clientid uint32 // alpaca client id
-	var debug bool      // enable debugging
-	var sport int32     // Alpaca server port
-	var shost string    // Alpaca server IP
-	var version bool    //  Version info
-	var _mode string    // Comms mode
+	var lport int32        // listen port
+	var lip string         // listen IP
+	var clientid uint32    // alpaca client id
+	var debug bool         // enable debugging
+	var sport int32        // Alpaca server port
+	var shost string       // Alpaca server IP
+	var version bool       //  Version info
+	var _mode string       // Comms mode
+	var highPrecision bool // used for LX200
 	var noAutoTrack bool
 	var mode TeleComms
 	var telescopeId uint32 // Alpaca telescope id.  Usually 0-10
@@ -74,6 +75,7 @@ func main() {
 	flag.Uint32Var(&telescopeId, "telescope-id", 0, "Alpaca Telescope ID")
 	flag.StringVar(&_mount_type, "mount-type", "altaz", "Mount type: [altaz|eqn|eqs]")
 	flag.BoolVar(&noAutoTrack, "no-auto-track", false, "Do not enable auto-track")
+	flag.BoolVar(&highPrecision, "high-precision", false, "Default to High Precision LX200 mode")
 
 	flag.Parse()
 
@@ -186,7 +188,7 @@ func main() {
 		if err != nil {
 			log.Errorf("Unable to query axis rates: %s", err.Error())
 		}
-		tscope = telescope.NewLX200(!noAutoTrack, true, true, minmax, 100000)
+		tscope = telescope.NewLX200(!noAutoTrack, highPrecision, true, minmax, 100000)
 	case NexStar:
 		tscope = telescope.NewNexStar(!noAutoTrack)
 	default:

--- a/gui/config.go
+++ b/gui/config.go
@@ -27,19 +27,20 @@ import (
 
 // Our actual application config
 type AlpacaScopeConfig struct {
-	TelescopeProtocol string `json:"TelescopeProtocol"`
-	TelescopeMount    string `json:"TelescopeMount"`
-	AutoTracking      bool   `json:"AutoTracking"`
-	ListenIp          string `json:"ListenIp"`
-	ListenPort        string `json:"ListenPort"`
-	AscomAuto         bool   `json:"AscomAuto"`
-	AscomIp           string `json:"AscomIp"`
-	AscomPort         string `json:"AscomPort"`
-	AscomTelescope    string `json:"AscomTelescope"`
-	isRunning         bool
-	Quit              chan bool      `json:"-"` // have to hide since public
-	EnableButtons     chan bool      `json:"-"`
-	store             *SettingsStore // platform specific
+	TelescopeProtocol  string `json:"TelescopeProtocol"`
+	TelescopeMount     string `json:"TelescopeMount"`
+	AutoTracking       bool   `json:"AutoTracking"`
+	ListenIp           string `json:"ListenIp"`
+	ListenPort         string `json:"ListenPort"`
+	AscomAuto          bool   `json:"AscomAuto"`
+	AscomIp            string `json:"AscomIp"`
+	AscomPort          string `json:"AscomPort"`
+	AscomTelescope     string `json:"AscomTelescope"`
+	HighPrecisionLX200 bool   `json:"HighPrecisionLX200"`
+	isRunning          bool
+	Quit               chan bool      `json:"-"` // have to hide since public
+	EnableButtons      chan bool      `json:"-"`
+	store              *SettingsStore // platform specific
 }
 
 // Loads the config from our SettingsStore (if it exists),
@@ -47,18 +48,19 @@ type AlpacaScopeConfig struct {
 // so you know why loading settings failed.
 func NewAlpacaScopeConfig() *AlpacaScopeConfig {
 	config := &AlpacaScopeConfig{
-		TelescopeProtocol: "NexStar",
-		TelescopeMount:    "Alt-Az",
-		AutoTracking:      true,
-		AscomAuto:         true,
-		ListenIp:          "All-Interfaces/0.0.0.0",
-		ListenPort:        "4030",
-		AscomIp:           "127.0.0.1",
-		AscomPort:         alpaca.DEFAULT_PORT_STR,
-		AscomTelescope:    "0",
-		Quit:              make(chan bool),
-		EnableButtons:     make(chan bool),
-		store:             NewSettingsStore(),
+		TelescopeProtocol:  "NexStar",
+		TelescopeMount:     "Alt-Az",
+		HighPrecisionLX200: false,
+		AutoTracking:       true,
+		AscomAuto:          true,
+		ListenIp:           "All-Interfaces/0.0.0.0",
+		ListenPort:         "4030",
+		AscomIp:            "127.0.0.1",
+		AscomPort:          alpaca.DEFAULT_PORT_STR,
+		AscomTelescope:     "0",
+		Quit:               make(chan bool),
+		EnableButtons:      make(chan bool),
+		store:              NewSettingsStore(),
 	}
 
 	return config

--- a/gui/main.go
+++ b/gui/main.go
@@ -46,18 +46,19 @@ const (
 var sbox *StatusBox
 
 type Widgets struct {
-	TelescopeProtocol *widget.Select
-	TelescopeMount    *widget.Select
-	AutoTracking      *widget.Check
-	ListenIp          *widget.Select
-	ListenPort        *widget.Entry
-	AscomAuto         *widget.Check
-	AscomIp           *widget.Entry
-	AscomPort         *widget.Entry
-	AscomTelescope    *widget.Select
-	Status            *widget.TextGrid
-	Save              *widget.Button
-	Delete            *widget.Button
+	TelescopeProtocol  *widget.Select
+	TelescopeMount     *widget.Select
+	AutoTracking       *widget.Check
+	HighPrecisionLX200 *widget.Check
+	ListenIp           *widget.Select
+	ListenPort         *widget.Entry
+	AscomAuto          *widget.Check
+	AscomIp            *widget.Entry
+	AscomPort          *widget.Entry
+	AscomTelescope     *widget.Select
+	Status             *widget.TextGrid
+	Save               *widget.Button
+	Delete             *widget.Button
 }
 
 func main() {
@@ -80,6 +81,7 @@ func main() {
 	top := widget.NewForm(
 		widget.NewFormItem("Telescope Protocol", ourWidgets.TelescopeProtocol),
 		widget.NewFormItem("Mount Type", ourWidgets.TelescopeMount),
+		widget.NewFormItem("", ourWidgets.HighPrecisionLX200),
 		widget.NewFormItem("Auto Tracking", ourWidgets.AutoTracking),
 		widget.NewFormItem("Listen IP", ourWidgets.ListenIp),
 		widget.NewFormItem("Listen Port", ourWidgets.ListenPort),
@@ -393,9 +395,12 @@ func NewWidgets(config *AlpacaScopeConfig) *Widgets {
 			config.TelescopeProtocol = proto
 			if proto == "NexStar" {
 				w.TelescopeMount.Enable()
+				w.HighPrecisionLX200.Disable()
 			} else {
 				// only NexStar supports the mountType
 				w.TelescopeMount.Disable()
+				// only LX200 supports high precision
+				w.HighPrecisionLX200.Enable()
 			}
 		},
 	)
@@ -406,15 +411,20 @@ func NewWidgets(config *AlpacaScopeConfig) *Widgets {
 
 	// AutoTracking
 	w.AutoTracking = widget.NewCheck("", func(enabled bool) {
-		switch enabled {
-		case true:
-			config.AutoTracking = true
-		case false:
-			config.AutoTracking = false
-		}
-
+		config.AutoTracking = enabled
 	})
 	w.AutoTracking.Checked = config.AutoTracking
+
+	// HighPrecisionLX200
+	w.HighPrecisionLX200 = widget.NewCheck("Default to using High Precision", func(enabled bool) {
+		config.HighPrecisionLX200 = enabled
+	})
+	w.HighPrecisionLX200.Checked = config.HighPrecisionLX200
+	if config.TelescopeProtocol == "LX200" {
+		w.HighPrecisionLX200.Enable()
+	} else {
+		w.HighPrecisionLX200.Disable()
+	}
 
 	// ListenIp
 	ips, err := utils.GetLocalIPs()
@@ -491,6 +501,7 @@ func NewWidgets(config *AlpacaScopeConfig) *Widgets {
 
 func (w *Widgets) Set(config *AlpacaScopeConfig) {
 	w.TelescopeProtocol.SetSelected(config.TelescopeProtocol)
+	w.HighPrecisionLX200.SetChecked(config.HighPrecisionLX200)
 	w.TelescopeMount.SetSelected(config.TelescopeMount)
 	w.AutoTracking.SetChecked(config.AutoTracking)
 	w.ListenIp.SetSelected(config.ListenIp)

--- a/gui/main.go
+++ b/gui/main.go
@@ -46,6 +46,7 @@ const (
 var sbox *StatusBox
 
 type Widgets struct {
+	form               *widget.Form
 	TelescopeProtocol  *widget.Select
 	TelescopeMount     *widget.Select
 	AutoTracking       *widget.Check
@@ -80,8 +81,8 @@ func main() {
 
 	top := widget.NewForm(
 		widget.NewFormItem("Telescope Protocol", ourWidgets.TelescopeProtocol),
-		widget.NewFormItem("Mount Type", ourWidgets.TelescopeMount),
-		widget.NewFormItem("", ourWidgets.HighPrecisionLX200),
+		widget.NewFormItem("NexStar Mount Type", ourWidgets.TelescopeMount),
+		widget.NewFormItem("LX200 default to High Precision", ourWidgets.HighPrecisionLX200),
 		widget.NewFormItem("Auto Tracking", ourWidgets.AutoTracking),
 		widget.NewFormItem("Listen IP", ourWidgets.ListenIp),
 		widget.NewFormItem("Listen Port", ourWidgets.ListenPort),
@@ -90,6 +91,7 @@ func main() {
 		widget.NewFormItem("ASCOM Remote Port", ourWidgets.AscomPort),
 		widget.NewFormItem("ASCOM Telescope ID", ourWidgets.AscomTelescope),
 	)
+	ourWidgets.form = top
 
 	ourWidgets.Save = widget.NewButton("Save Settings", func() {
 		err := config.Save()
@@ -402,6 +404,7 @@ func NewWidgets(config *AlpacaScopeConfig) *Widgets {
 				// only LX200 supports high precision
 				w.HighPrecisionLX200.Enable()
 			}
+			w.form.Refresh()
 		},
 	)
 	w.TelescopeProtocol.Selected = config.TelescopeProtocol
@@ -412,12 +415,14 @@ func NewWidgets(config *AlpacaScopeConfig) *Widgets {
 	// AutoTracking
 	w.AutoTracking = widget.NewCheck("", func(enabled bool) {
 		config.AutoTracking = enabled
+		w.form.Refresh()
 	})
 	w.AutoTracking.Checked = config.AutoTracking
 
 	// HighPrecisionLX200
-	w.HighPrecisionLX200 = widget.NewCheck("Default to using High Precision", func(enabled bool) {
+	w.HighPrecisionLX200 = widget.NewCheck("", func(enabled bool) {
 		config.HighPrecisionLX200 = enabled
+		w.form.Refresh()
 	})
 	w.HighPrecisionLX200.Checked = config.HighPrecisionLX200
 	if config.TelescopeProtocol == "LX200" {
@@ -476,7 +481,7 @@ func NewWidgets(config *AlpacaScopeConfig) *Widgets {
 			w.AscomIp.Enable()
 			w.AscomPort.Enable()
 		}
-
+		w.form.Refresh()
 	})
 	w.AscomAuto.Checked = config.AscomAuto
 	if config.AscomAuto {

--- a/telescope/lx200.go
+++ b/telescope/lx200.go
@@ -29,7 +29,7 @@ type LX200 struct {
 	year           int
 }
 
-func NewLX200(autoTrack bool, highPrecision, twentyfourhr bool, rates map[string]float64, utcoffset float64) *LX200 {
+func NewLX200(autoTrack, highPrecision, twentyfourhr bool, rates map[string]float64, utcoffset float64) *LX200 {
 	state := LX200{
 		AutoTrack:      autoTrack,
 		HighPrecision:  highPrecision,

--- a/telescope/lx200.go
+++ b/telescope/lx200.go
@@ -372,7 +372,8 @@ func (state *LX200) lx200_command(t *alpaca.Telescope, cmdlen int, buf []byte) (
 			var degrees, min, sec int
 			var sign byte
 			var dms DMS
-			if state.HighPrecision {
+			switch strings.Count(cmd, ":") {
+			case 2:
 				// sDD:MM:SS
 				_, err = fmt.Sscanf(cmd, ":Sd%c%02d*%02d:%02d#", &sign, &degrees, &min, &sec)
 				if err != nil {
@@ -383,7 +384,7 @@ func (state *LX200) lx200_command(t *alpaca.Telescope, cmdlen int, buf []byte) (
 					degrees *= -1
 				}
 				dms = NewDMS(degrees, min, float64(sec))
-			} else {
+			case 1:
 				// sDD:MM
 				_, err = fmt.Sscanf(cmd, ":Sd%c%02d*%02d#", &sign, &degrees, &min)
 				if err != nil {
@@ -394,6 +395,9 @@ func (state *LX200) lx200_command(t *alpaca.Telescope, cmdlen int, buf []byte) (
 					degrees *= -1
 				}
 				dms = NewDMSShort(degrees, float64(min))
+			default:
+				log.Errorf("Unable to parse %s", cmd)
+				ret = "0"
 			}
 			if ret == "" {
 				err = t.PutTargetDeclination(dms.Float)
@@ -487,7 +491,8 @@ func (state *LX200) lx200_command(t *alpaca.Telescope, cmdlen int, buf []byte) (
 			// Set target RA
 			var hour, min, sec int
 			var hms HMS
-			if state.HighPrecision {
+			switch strings.Count(cmd, ":") {
+			case 3:
 				// HH:MM:SS
 				_, err = fmt.Sscanf(cmd, ":Sr%02d:%02d:%02d#", &hour, &min, &sec)
 				if err != nil {
@@ -495,7 +500,7 @@ func (state *LX200) lx200_command(t *alpaca.Telescope, cmdlen int, buf []byte) (
 					ret = "0"
 				}
 				hms = NewHMS(hour, min, float64(sec))
-			} else {
+			case 2:
 				// HH:MM.T  not sure what T is.  Assuming is tenth of sec?
 				_, err = fmt.Sscanf(cmd, ":Sr%02d:%02d.%d#", &hour, &min, &sec)
 				if err != nil {
@@ -504,6 +509,9 @@ func (state *LX200) lx200_command(t *alpaca.Telescope, cmdlen int, buf []byte) (
 				}
 				min_float := float64(min) + (float64(sec) / 10.0)
 				hms = NewHMSShort(hour, min_float)
+			default:
+				log.Errorf("Unable to parse %s", cmd)
+				ret = "0"
 			}
 
 			if ret == "" {


### PR DESCRIPTION
SNPro 8 and other clients by default are not using high precision
mode with LX200.  Since there doesn't seem to be a way to query
the mount, we need to allow people to change the default to match
whatever the client (SkySafari, StarryNight, etc) assume to be true.

Fixes #51